### PR TITLE
Allow Helm release to be named directly

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "this" {
 
   # Allows var.name to be empty, which is allowed to be the case for this module since var.name is optional in eks-iam-role.
   # For more information, see: https://github.com/cloudposse/terraform-aws-eks-iam-role
-  name = coalesce(module.this.name, var.chart)
+  name = coalesce(var.release_name, module.this.name, var.chart)
 
   chart       = var.chart
   description = var.description

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,12 @@ variable "devel" {
   default     = null
 }
 
+variable "release_name" {
+  type = string
+  description = "Release name to be used. If empty, the release"
+  default = null
+}
+
 variable "repository" {
   type        = string
   description = "Repository URL where to locate the requested chart."


### PR DESCRIPTION
## what
Allow the Helm version to be named directly without having to overwrite the context name.

Sometimes it can be useful to set the Helm version name directly without using the context name. It could also be useful to avoid duplication in IAM policy and role names.

## why
Allows to deploy two releases of the same Helm chart (external-dns) with different names, for example: external-dns-public and external-dns-private, but using the same context (environment, stage and name).

## references
 * Issue: https://github.com/cloudposse/terraform-aws-helm-release/issues/22

